### PR TITLE
Add singleton dependency graph validation

### DIFF
--- a/pkg/ContainerBuilder/ContainerBuilder.go
+++ b/pkg/ContainerBuilder/ContainerBuilder.go
@@ -15,18 +15,18 @@ import (
 )
 
 type ContainerBuilder struct {
-	built bool
+	built              bool
 	namedRegistrations map[string]*r.Registration
-	grouped map[string]*g.Group
-	cache map[reflect.Type][]*r.Registration
+	grouped            map[string]*g.Group
+	cache              map[reflect.Type][]*r.Registration
 }
 
 func New() *ContainerBuilder {
 	return &ContainerBuilder{
-		built: false,
+		built:              false,
 		namedRegistrations: make(map[string]*r.Registration),
-		grouped: make(map[string]*g.Group),
-		cache: make(map[reflect.Type][]*r.Registration),
+		grouped:            make(map[string]*g.Group),
+		cache:              make(map[reflect.Type][]*r.Registration),
 	}
 }
 
@@ -54,8 +54,8 @@ func (cb *ContainerBuilder) Register(
 		groupName := groupInfo.Name
 		if cb.grouped[groupName] == nil {
 			cb.grouped[groupName] = &g.Group{
-				Registrations : make([]*r.Registration, 0),
-				GroupInfo: groupInfo,
+				Registrations: make([]*r.Registration, 0),
+				GroupInfo:     groupInfo,
 			}
 		} else {
 			if cb.grouped[groupName].GroupType != groupInfo.GroupType {
@@ -116,6 +116,10 @@ func (cb *ContainerBuilder) Build() (*gf.Container, error) {
 		Options.AsSingleton,
 	)
 	if err != nil {
+		return nil, err
+	}
+
+	if err := cb.analyzeDependencies(); err != nil {
 		return nil, err
 	}
 

--- a/pkg/ContainerBuilder/ContainerBuilder_test.go
+++ b/pkg/ContainerBuilder/ContainerBuilder_test.go
@@ -5,9 +5,9 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/TaBSRest/GoFac"
 	i "github.com/TaBSRest/GoFac/interfaces"
 	cb "github.com/TaBSRest/GoFac/pkg/ContainerBuilder"
-	"github.com/TaBSRest/GoFac"
 	"github.com/TaBSRest/GoFac/pkg/Options"
 	ss "github.com/TaBSRest/GoFac/tests/SampleStructs"
 )
@@ -83,3 +83,24 @@ func TestGetRegistrations_ReturnedValuesAreImmutable(t *testing.T) {
 	assert.Equal(2, len(newCopy))
 }
 
+func TestBuild_FailsWhenSingletonDependsOnPerScope(t *testing.T) {
+	assert := assert.New(t)
+
+	containerBuilder := cb.New()
+	err := containerBuilder.Register(
+		ss.NewIndependentStruct,
+		Options.PerScope,
+		Options.As[ss.IIndependentStruct],
+	)
+	assert.Nil(err)
+
+	err = containerBuilder.Register(
+		ss.NewStructRelyingOnIndependentStruct,
+		Options.AsSingleton,
+		Options.As[ss.IStructRelyingOnIndependentStruct],
+	)
+	assert.Nil(err)
+
+	_, err = containerBuilder.Build()
+	assert.NotNil(err, "Build should fail when singleton depends on PerScope dependency")
+}

--- a/pkg/ContainerBuilder/dependency_analyzer.go
+++ b/pkg/ContainerBuilder/dependency_analyzer.go
@@ -1,0 +1,79 @@
+package ContainerBuilder
+
+import (
+	"fmt"
+
+	h "github.com/TaBSRest/GoFac/internal/Helpers"
+	r "github.com/TaBSRest/GoFac/internal/Registration"
+	s "github.com/TaBSRest/GoFac/internal/Scope"
+	te "github.com/TaBSRest/GoFac/internal/TaBSError"
+)
+
+// analyzeDependencies ensures that singleton registrations do not depend on
+// registrations with PerScope lifetime. It returns an error if such a
+// dependency is found.
+func (cb *ContainerBuilder) analyzeDependencies() error {
+	// Track visited registrations to avoid processing the same registration
+	// multiple times during the root iteration.
+	visited := make(map[*r.Registration]bool)
+	for _, regs := range cb.cache {
+		for _, reg := range regs {
+			if visited[reg] {
+				continue
+			}
+			visited[reg] = true
+			if reg.Options.Scope == s.Singleton {
+				if err := cb.checkSingletonDependencies(reg, make(map[*r.Registration]bool)); err != nil {
+					return err
+				}
+			}
+		}
+	}
+	return nil
+}
+
+// checkSingletonDependencies recursively checks that the provided singleton
+// registration does not depend (directly or indirectly) on any PerScope
+// registration.
+func (cb *ContainerBuilder) checkSingletonDependencies(reg *r.Registration, stack map[*r.Registration]bool) error {
+	if stack[reg] {
+		return nil
+	}
+	stack[reg] = true
+
+	ctorInfo := reg.Construction.Info
+	for i := 0; i < ctorInfo.NumIn(); i++ {
+		depType := ctorInfo.In(i)
+
+		// If dependency is an array or slice, analyze each registration of the element type.
+		if h.IsArrayOrSlice(depType) {
+			elemType := depType.Elem()
+			depRegs, found := cb.cache[elemType]
+			if !found {
+				continue
+			}
+			for _, dr := range depRegs {
+				if dr.Options.Scope == s.PerScope {
+					return te.New(fmt.Sprintf("Singleton %s depends on PerScope registration %s", ctorInfo, elemType))
+				}
+				if err := cb.checkSingletonDependencies(dr, stack); err != nil {
+					return err
+				}
+			}
+			continue
+		}
+
+		depRegs, found := cb.cache[depType]
+		if !found || len(depRegs) == 0 {
+			continue
+		}
+		depReg := depRegs[len(depRegs)-1]
+		if depReg.Options.Scope == s.PerScope {
+			return te.New(fmt.Sprintf("Singleton %s depends on PerScope registration %s", ctorInfo, depType))
+		}
+		if err := cb.checkSingletonDependencies(depReg, stack); err != nil {
+			return err
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
## Summary
- prevent building a container when a singleton depends on a PerScope registration
- implement dependency graph analyzer to inspect registration lifetimes
- add test ensuring build fails for invalid dependency graph

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_b_68b506b51d848332aaed3a09b9c09b15